### PR TITLE
Make [DEFAULT] section work without passing --server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Keys that are not specified in named sections will fall back to the key in `[DEF
 The following keys are supported in each section:
 | Key      | Notes |
 | -------- | ----- |
+| username | REQUIRED. <br>On CLI, this is `--user`. |
+| password | REQUIRED. <br>Allowed to be empty (but the key must still be present). <br>The escape character is `%`, so a percent sign in your password will need to be escaped as `%%`. |
 | server   | Does NOT override `--server`, so it's best to not specify this outside of `[DEFAULT]`. |
-| port     | |
-| insecure | true or false. Communicate with library over http:// instead of https:// |
-| username | On CLI, this is `--user` |
-| password | Allowed to be empty (but the key must still be present). The escape character is `%`, so a percent sign in your password will need to be escaped as `%%`. |
-| verbose  | true or false. |
+| port     | Port on which to communicate with the library. <br>Default is 443, or 80 if `insecure=true`. |
+| insecure | Communicate with the library over http:// instead of https://. <br>`true` or `false`; defaults to `false` (use https://). |
+| verbose  | Increase the verbosity for the output. <br>`true` or `false`. |
 
 Comments are allowed, the comment prefix is `#`.
 
@@ -66,6 +66,7 @@ insecure = true
 username = su
 password = supersecret!
 ```
+In this example, library _theoneweneveruse_ will also use insecure (http://) communications, because it inherits the `insecure` key from `[DEFAULT]` (as well as the `verbose` key).
 
 Documentation
 ----------------

--- a/README.md
+++ b/README.md
@@ -30,6 +30,43 @@ repository enabled.  Our RHEL7-based systems have python34 installed.
     Install  1 Package (+5 Dependent packages)
     <snip>
 
+Configuration files
+----------------
+
+Unless overridden by `--config`, SLAPI will pick up a system-wide configuration file in `/etc/slapi.conf` or a user-specific configuration file in `~/.slapi/slapi.conf`.
+
+The configuration file is a simple INI file. If you specify `--server`, the section with that exact same name will be read; if you do not specify a server, the `[DEFAULT]` section will be read instead and the `server` key in that section will be used. Do not specify `server` in named sections; it will not override what you pass on the CLI.
+
+Keys that are not specified in named sections will fall back to the key in `[DEFAULT]` if present there.
+
+The following keys are supported in each section:
+| Key      | Notes |
+| -------- | ----- |
+| server   | Does NOT override `--server`, so it's best to not specify this outside of `[DEFAULT]`. |
+| port     | |
+| insecure | true or false. Communicate with library over http:// instead of https:// |
+| username | On CLI, this is `--user` |
+| password | Allowed to be empty (but the key must still be present). The escape character is `%`, so a percent sign in your password will need to be escaped as `%%`. |
+| verbose  | true or false. |
+
+Comments are allowed, the comment prefix is `#`.
+
+Here is a sample configuration file with two libraries:
+
+``` INI
+[DEFAULT]
+server = tfinity01.mydomain.com
+username = su
+# % escaped as %%
+password = ThisPwdHasOnlyOne%%.
+verbose = false
+insecure = true
+
+[theoneweneveruse.mydomain.com]
+username = su
+password = supersecret!
+```
+
 Documentation
 ----------------
 

--- a/src/slapi.py
+++ b/src/slapi.py
@@ -5208,7 +5208,7 @@ def main():
                            help='Configuration file for Spectra Logic API.')
 
     cmdparser.add_argument('--server', '-s', dest='server',
-                           required=True,
+                           required=False,
                            help='Hostname/IP Address of Spectra Logic Library.')
 
     cmdparser.add_argument('--port', '-P', dest='port',
@@ -5583,6 +5583,9 @@ def main():
             config = cfgparser["DEFAULT"]
 
         try:
+            if args.server is None:
+                if config.get("server"):
+                    args.server = config["server"]
             if args.user is None:
                 if config.get("username"):
                     args.user   = config["username"]


### PR DESCRIPTION
Thank you for creating a great tool that Spectra themselves apparently can't be bothered to :-)

Two things bothered me: the lack of documentation about slapi.conf, and the fact that the DEFAULT section in there doesn't actually work unless you pass --server anyway - which is a medium inconvenience if you only have the one TFinity :stuck_out_tongue:

So, here's a small PR fixing both those issues. It occurs to me that it might be useful to be able to override the --server flag with a server key in the config file as well, as it'd allow for convenient aliases; but that's a larger change so I can't really justify spending the time on that :smile: 